### PR TITLE
Fix typo in b0_dwi1 var name

### DIFF
--- a/alps.sh
+++ b/alps.sh
@@ -356,7 +356,7 @@ if [ $skip -eq 0 ]; then
 			if [ "$bval2" ]; then #if you don't have a bval2 file, then assume it equal to b0_dwi1, that should be 0.
    				b0_dwi2=`head -c 1 "$bval2"`
        			else
-	  			b0_dwi2=$b0_dw1
+	  			b0_dwi2=$b0_dwi1
       			fi
 			if [ "${PEdir1}" == "${PEdir2}-" ] || [ "${PEdir2}" == "${PEdir1}-" ] && ([ "${b0_dwi1}" == "${b0_dwi2}" ] && [ "${b0_dwi1}" == "0" ]);
 			then


### PR DESCRIPTION
When 2 DWI scans are provided (a main one and a secondary for the distortion correction step) but the secondary scan has no bval/bvec files (since eg. is just a b0 volume scan, as is my case), `alps.sh` then assigns the b-value of the first volume from the main scan to the secondary, guessing/assuming it should be the same value (it could be directly set to zero/null, btw).  
However, this assignment has a typo error in the variable name `b0_dwi1` crashing the script execution flow. 
