### PR TITLE
Fix issue with id assignment for non .nii/.nii.gz filenames

### DIFF
--- a/alps.sh
+++ b/alps.sh
@@ -653,6 +653,8 @@ then
 		id="$(basename "$dwi1" .nii)"
 	elif [[ $dwi1 == *".nii.gz" ]]; then
 		id="$(basename "$dwi1" .nii.gz)"
+	else
+		id="$(basename "$dwi1")"
 	fi
 
 	x_proj_L="$(fslstats "${dxx}" -k "${proj_L}" -m)"


### PR DESCRIPTION
When using a command like the following:
```
# The situation is that the DWI files have already been preprocessed, and the script is only used to calculate the ALPS index
alps.sh -a test -r 1 -t 1 -o /mnt/f/BIDS/SVD_BIDS/derivatives/fdt/sub-SVD0035/ses-02/DTI-ALPS -s 1
```
However, the id column in the generated CSV file is empty. It seems that the script does not handle the case when id is not a NIfTI file, but the README mentions that the `-a myID` format can be used directly.